### PR TITLE
Define portable editor configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_style = space
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Addresses #26 

Using https://editorconfig.org/, works best with [editor plugins](https://editorconfig.org/#download)